### PR TITLE
[Fix] Saving services

### DIFF
--- a/src/controllers/agent.ts
+++ b/src/controllers/agent.ts
@@ -13,7 +13,7 @@ export default class AgentController {
    * @param res - response
    */
   public static async updateServices(req: express.Request, res: express.Response): Promise<void> {
-    const workspace: Workspace | null = await WorkspacesService.updateServices(req.headers.authorization, req.body.services);
+    const workspace: Workspace | null = await WorkspacesService.updateServices(req.headers.authorization, req.body.payload.services);
 
     if (workspace) {
       req.app.context.transport


### PR DESCRIPTION
Information about services comes in `body.payload.services`, not in `body.services`.